### PR TITLE
Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
 # SimpleOS
 	Code from http://wiki.osdev.org/Bare_Bones
 
-# How to build the source
-	./build.sh
+## How to build the source
 
-#How to run the binary
-	qemu-system-i386 -kernel kernel.bin
+```sh
+./build.sh
+```
 
-	
-#Platforms
-	Tested on Ubuntu 14.10 64bit	
+# How to run the binary
+
+```sh
+qemu-system-i386 -kernel kernel.bin
+```
+
+## Platforms
+        Tested on Ubuntu 14.10 64bit


### PR DESCRIPTION
## Summary
- fix spacing for headers in README
- remove extraneous blank line
- format README commands with fenced code blocks
- shrink build and platform headings

## Testing
- `bash build.sh` *(fails: cannot find -lgcc)*

------
https://chatgpt.com/codex/tasks/task_e_686ddee975d88325915556c09b438627